### PR TITLE
NAS-113865 / Protect from null dereference in export_to_dbus()

### DIFF
--- a/src/include/export_mgr.h
+++ b/src/include/export_mgr.h
@@ -282,8 +282,10 @@ static inline void tmp_get_exp_paths(struct tmp_export_paths *tmp,
 
 	if (gr != NULL)
 		tmp->tmp_pseudopath = gsh_refstr_get(gr);
-	else
+	else if (exp->cfg_pseudopath != NULL)
 		tmp->tmp_pseudopath = gsh_refstr_dup(exp->cfg_pseudopath);
+	else
+		tmp->tmp_pseudopath = gsh_refstr_dup("No Export");
 
 	rcu_read_unlock();
 }


### PR DESCRIPTION
If share is NFSv3 without the pseudopath parameter
defined then NULL dereference can occur during
export_to_dbus().

Initialize to "No Export" if NULL, which is consistent with what happens when FSAL is committed.