### PR TITLE
NAS-113911 / Fix logic for determining whether to use pseudopath

### DIFF
--- a/src/support/export_mgr.c
+++ b/src/support/export_mgr.c
@@ -1555,7 +1555,7 @@ static bool export_to_dbus(struct gsh_export *exp_node, void *state)
 
 	path = TMP_PSEUDOPATH(&tmp);
 
-	if (path == NULL) {
+	if (strcmp(path, "No Export") == 0) {
 
 		path = TMP_FULLPATH(&tmp);
 		if (path == NULL)


### PR DESCRIPTION
Now that we set pseudo-path to "No Export" when it's undefined,
we need to check for this string when determining whether to
export the full path to dbus.